### PR TITLE
Bind `TAB` to `+showscores` instead of `+BOARD`

### DIFF
--- a/cfg/_HL_casting.cfg
+++ b/cfg/_HL_casting.cfg
@@ -33,7 +33,7 @@ bind "z" "ce_teamnames_swap" 		// Swaps team names around
 bind "ENTER" "say"
 bind "SPACE" "+jump"
 bind "BACKSPACE" "say_team"
-bind "TAB" "+BOARD"
+bind "TAB" "+showscores"
 bind "ESCAPE" "cancelselect"
 bind "PAUSE" "pause"
 bind "SHIFT" "+moveup"

--- a/cfg/autoexec.cfg
+++ b/cfg/autoexec.cfg
@@ -34,7 +34,7 @@ bind "z" "ce_teamnames_swap" 		// Swaps team names around
 bind "ENTER" "say"
 bind "SPACE" "+jump"
 bind "BACKSPACE" "say_team"
-bind "TAB" "+BOARD"
+bind "TAB" "+showscores"
 bind "ESCAPE" "cancelselect"
 bind "PAUSE" "pause"
 bind "SHIFT" "+moveup"


### PR DESCRIPTION
`+BOARD` is not aliased anywhere, and it's weird capitalization makes me believe it wasn't intended to be in this config like this. We'll use the standard `+showscores` instead.